### PR TITLE
Replace deprecated ioutil.ReadAll with io.ReadAll and refactored 

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -12,9 +12,8 @@ import (
 )
 
 var (
-	mainnetAPI = "https://api.opensea.io"
-	rinkebyAPI = "https://rinkeby-api.opensea.io"
-
+	mainnetAPI          = "https://api.opensea.io"
+	rinkebyAPI          = "https://rinkeby-api.opensea.io"
 	basePath            = "/api/v1"
 	singleAssetEndpoint = basePath + "/asset"
 )
@@ -24,163 +23,6 @@ type Opensea struct {
 	APIKey     string
 	httpClient *http.Client
 }
-
-type Address string
-
-type Collection struct {
-	// todo: Support commented fields in Collection struct for /collections GET request
-	//PrimaryAssetContracts
-	//Traits
-	//Stats
-	BannerImageUrl              string      `json:"banner_image_url" bson:"banner_image_url"`
-	ChatUrl                     string      `json:"chat_url" bson:"chat_url"`
-	CreatedDate                 string      `json:"created_date" bson:"created_date"`
-	DefaultToFiat               bool        `json:"default_to_fiat" bson:"default_to_fiat"`
-	Description                 string      `json:"description" bson:"description"`
-	DevBuyerFeeBasisPoints      string      `json:"dev_buyer_fee_basis_points" bson:"dev_buyer_fee_basis_points"`
-	DevSellerFeeBasisPoints     string      `json:"dev_seller_fee_basis_points" bson:"dev_seller_fee_basis_points"`
-	DiscordUrl                  string      `json:"discord_url" bson:"discord_url"`
-	DisplayData                 interface{} `json:"display_data" bson:"display_data"`
-	ExternalUrl                 string      `json:"external_url" bson:"external_url"`
-	Featured                    bool        `json:"featured" bson:"featured"`
-	FeaturedImageUrl            string      `json:"featured_image_url" bson:"featured_image_url"`
-	Hidden                      bool        `json:"hidden" bson:"hidden"`
-	SafelistRequestStatus       string      `json:"safelist_request_status" bson:"safelist_request_status"`
-	ImageUrl                    string      `json:"image_url" bson:"image_url"`
-	IsSubjectToWhitelist        bool        `json:"is_subject_to_whitelist" bson:"is_subject_to_whitelist"`
-	LargeImageUrl               string      `json:"large_image_url" bson:"large_image_url"`
-	MediumUsername              string      `json:"medium_username" bson:"medium_username"`
-	Name                        string      `json:"name" bson:"name"`
-	OnlyProxiedTransfers        bool        `json:"only_proxied_transfers" bson:"only_proxied_transfers"`
-	OpenseaBuyerFeeBasisPoints  string      `json:"opensea_buyer_fee_basis_points" bson:"opensea_buyer_fee_basis_points"`
-	OpenseaSellerFeeBasisPoints string      `json:"opensea_seller_fee_basis_points" bson:"opensea_seller_fee_basis_points"`
-	PayoutAddress               string      `json:"payout_address" bson:"payout_address"`
-	RequireEmail                bool        `json:"require_email" bson:"require_email"`
-	ShortDescription            string      `json:"short_description" bson:"short_description"`
-	Slug                        string      `json:"slug" bson:"slug"`
-	TelegramUrl                 string      `json:"telegram_url" bson:"telegram_url"`
-	TwitterUsername             string      `json:"twitter_username" bson:"twitter_username"`
-	InstagramUsername           string      `json:"instagram_username" bson:"instagram_username"`
-	WikiUrl                     string      `json:"wiki_url" bson:"wiki_url"`
-	//IsNSFW                      bool        `json:"is_nsfw" bson:"is_nsfw"`
-	//Fees                        interface{} `json:"fees" bson:"fees"`
-	//IsRarityEnabled             bool        `json:"is_rarity_enabled" bson:"is_rarity_enabled"`
-	//IsCreatorFeesEnforced       bool        `json:"is_creator_fees_enforced" bson:"is_creator_fees_enforced"`
-}
-
-type User struct {
-	Username string `json:"username" bson:"username"`
-}
-type Account struct {
-	User          User    `json:"user" bson:"user"`
-	ProfileImgURL string  `json:"profile_img_url" bson:"profile_img_url"`
-	Address       Address `json:"address" bson:"address"`
-	Config        string  `json:"config" bson:"config"`
-	DiscordID     string  `json:"discord_id" bson:"discord_id"`
-}
-
-// AssetContract contains data about the contract itself, such as the Bored Ape Yacht Club contract.
-type AssetContract struct {
-	Address                     Address     `json:"address" bson:"address"`
-	AssetContractType           string      `json:"asset_contract_type" bson:"asset_contract_type"`
-	CreatedDate                 string      `json:"created_date" bson:"created_date"`
-	Name                        string      `json:"name" bson:"name"`
-	NftVersion                  string      `json:"nft_version" bson:"nft_version"`
-	OpenseaVersion              interface{} `json:"opensea_version" bson:"opensea_version"`
-	Owner                       int64       `json:"owner" bson:"owner"`
-	SchemaName                  string      `json:"schema_name" bson:"schema_name"`
-	Symbol                      string      `json:"symbol" bson:"symbol"`
-	TotalSupply                 interface{} `json:"total_supply" bson:"total_supply"`
-	Description                 string      `json:"description" bson:"description"`
-	ExternalLink                string      `json:"external_link" bson:"external_link"`
-	ImageURL                    string      `json:"image_url" bson:"image_url"`
-	DefaultToFiat               bool        `json:"default_to_fiat" bson:"default_to_fiat"`
-	DevBuyerFeeBasisPoints      int64       `json:"dev_buyer_fee_basis_points" bson:"dev_buyer_fee_basis_points"`
-	DevSellerFeeBasisPoints     int64       `json:"dev_seller_fee_basis_points" bson:"dev_seller_fee_basis_points"`
-	OnlyProxiedTransfers        bool        `json:"only_proxied_transfers" bson:"only_proxied_transfers"`
-	OpenseaBuyerFeeBasisPoints  int64       `json:"opensea_buyer_fee_basis_points" bson:"opensea_buyer_fee_basis_points"`
-	OpenseaSellerFeeBasisPoints int64       `json:"opensea_seller_fee_basis_points" bson:"opensea_seller_fee_basis_points"`
-	BuyerFeeBasisPoints         int64       `json:"buyer_fee_basis_points" bson:"buyer_fee_basis_points"`
-	SellerFeeBasisPoints        int64       `json:"seller_fee_basis_points" bson:"seller_fee_basis_points"`
-	PayoutAddress               Address     `json:"payout_address" bson:"payout_address"`
-}
-
-type Asset struct {
-	// todo: Support commented fields in Asset struct
-	ID                   int64          `json:"id" bson:"id"`
-	TokenID              string         `json:"token_id" bson:"token_id"`
-	NumSales             int64          `json:"num_sales" bson:"num_sales"`
-	BackgroundColor      string         `json:"background_color" bson:"background_color"`
-	ImageURL             string         `json:"image_url" bson:"image_url"`
-	ImagePreviewURL      string         `json:"image_preview_url" bson:"image_preview_url"`
-	ImageThumbnailURL    string         `json:"image_thumbnail_url" bson:"image_thumbnail_url"`
-	ImageOriginalURL     string         `json:"image_original_url" bson:"image_original_url"`
-	AnimationURL         string         `json:"animation_url" bson:"animation_url"`
-	AnimationOriginalURL string         `json:"animation_original_url" bson:"animation_original_url"`
-	Name                 string         `json:"name" bson:"name"`
-	Description          string         `json:"description" bson:"description"`
-	ExternalLink         string         `json:"external_link" bson:"external_link"`
-	AssetContract        *AssetContract `json:"asset_contract" bson:"asset_contract"`
-	Permalink            string         `json:"permalink" bson:"permalink"`
-	Collection           *Collection    `json:"collection" bson:"collection"`
-	Decimals             int64          `json:"decimals" bson:"decimals"`
-	TokenMetadata        string         `json:"token_metadata" bson:"token_metadata"`
-	//IsNSFW               bool           `json:"is_nsfw" bson:"is_nsfw"`
-	Owner *Account `json:"owner" bson:"owner"`
-	//SeaportSellOrders       string         `json:"seaport_sell_orders" bson:"seaport_sell_orders"`
-	//Creator                 *Creator       `json:"creator" bson:"creator"`
-	Traits interface{} `json:"traits" bson:"traits"`
-	//LastSale                string         `json:"last_sale" bson:"last_sale"`
-	//TopBid                  int64          `json:"top_bid" bson:"top_bid"`
-	//ListingDate             string         `json:"listing_date" bson:"listing_date"`
-	//SupportsWyvern          string         `json:"supports_wyvern" bson:"supports_wyvern"`
-	//RarityData              *RarityData    `json:"rarity_data" bson:"rarity_data"`
-	//TransferFee             int64          `json:"transfer_fee" bson:"transfer_fee"`
-	//TransferFeePaymentToken string         `json:"transfer_fee_payment_token" bson:"transfer_fee_payment_token"`
-}
-
-type errorResponse struct {
-	Success bool `json:"success" bson:"success"`
-}
-
-func (e errorResponse) Error() string {
-	return "Not success"
-}
-
-func NewOpensea(apiKey string) (*Opensea, error) {
-	o := &Opensea{
-		API:        mainnetAPI,
-		APIKey:     apiKey,
-		httpClient: defaultHttpClient(),
-	}
-	return o, nil
-}
-
-func NewOpenseaRinkeby(apiKey string) (*Opensea, error) {
-	o := &Opensea{
-		API:        rinkebyAPI,
-		APIKey:     apiKey,
-		httpClient: defaultHttpClient(),
-	}
-	return o, nil
-}
-
-// TODO
-//func (o Opensea) GetAssets(params GetAssetsParams) (*AssetResponse, error) {
-//	ctx := context.TODO()
-//	return o.GetAssetsWithContext(ctx, params)
-//}
-
-// TODO
-//func (o Opensea) GetAssetsWithContext(ctx context.Context, params GetAssetsParams) (*AssetResponse, error) {
-//	path := fmt.Sprintf("/api/v1/assets")
-//	b, err := o.GetPath(ctx, path)
-//	if err != nil {
-//		return nil, err
-//	}
-//	ret := new(AssetResponse)
-//	return ret, json.Unmarshal(b, ret)
-//}
 
 func (o Opensea) GetSingleAsset(assetContractAddress string, tokenID *big.Int) (*Asset, error) {
 	ctx := context.TODO()
@@ -215,7 +57,7 @@ func (o Opensea) getURL(ctx context.Context, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,123 @@
+package opensea
+
+type Address string
+
+type Collection struct {
+	// todo: Support commented fields in Collection struct for /collections GET request
+	//PrimaryAssetContracts
+	//Traits
+	//Stats
+	BannerImageUrl              string      `json:"banner_image_url" bson:"banner_image_url"`
+	ChatUrl                     string      `json:"chat_url" bson:"chat_url"`
+	CreatedDate                 string      `json:"created_date" bson:"created_date"`
+	DefaultToFiat               bool        `json:"default_to_fiat" bson:"default_to_fiat"`
+	Description                 string      `json:"description" bson:"description"`
+	DevBuyerFeeBasisPoints      string      `json:"dev_buyer_fee_basis_points" bson:"dev_buyer_fee_basis_points"`
+	DevSellerFeeBasisPoints     string      `json:"dev_seller_fee_basis_points" bson:"dev_seller_fee_basis_points"`
+	DiscordUrl                  string      `json:"discord_url" bson:"discord_url"`
+	DisplayData                 interface{} `json:"display_data" bson:"display_data"`
+	ExternalUrl                 string      `json:"external_url" bson:"external_url"`
+	Featured                    bool        `json:"featured" bson:"featured"`
+	FeaturedImageUrl            string      `json:"featured_image_url" bson:"featured_image_url"`
+	Hidden                      bool        `json:"hidden" bson:"hidden"`
+	SafelistRequestStatus       string      `json:"safelist_request_status" bson:"safelist_request_status"`
+	ImageUrl                    string      `json:"image_url" bson:"image_url"`
+	IsSubjectToWhitelist        bool        `json:"is_subject_to_whitelist" bson:"is_subject_to_whitelist"`
+	LargeImageUrl               string      `json:"large_image_url" bson:"large_image_url"`
+	MediumUsername              string      `json:"medium_username" bson:"medium_username"`
+	Name                        string      `json:"name" bson:"name"`
+	OnlyProxiedTransfers        bool        `json:"only_proxied_transfers" bson:"only_proxied_transfers"`
+	OpenseaBuyerFeeBasisPoints  string      `json:"opensea_buyer_fee_basis_points" bson:"opensea_buyer_fee_basis_points"`
+	OpenseaSellerFeeBasisPoints string      `json:"opensea_seller_fee_basis_points" bson:"opensea_seller_fee_basis_points"`
+	PayoutAddress               string      `json:"payout_address" bson:"payout_address"`
+	RequireEmail                bool        `json:"require_email" bson:"require_email"`
+	ShortDescription            string      `json:"short_description" bson:"short_description"`
+	Slug                        string      `json:"slug" bson:"slug"`
+	TelegramUrl                 string      `json:"telegram_url" bson:"telegram_url"`
+	TwitterUsername             string      `json:"twitter_username" bson:"twitter_username"`
+	InstagramUsername           string      `json:"instagram_username" bson:"instagram_username"`
+	WikiUrl                     string      `json:"wiki_url" bson:"wiki_url"`
+	//IsNSFW                      bool        `json:"is_nsfw" bson:"is_nsfw"`
+	//Fees                        interface{} `json:"fees" bson:"fees"`
+	//IsRarityEnabled             bool        `json:"is_rarity_enabled" bson:"is_rarity_enabled"`
+	//IsCreatorFeesEnforced       bool        `json:"is_creator_fees_enforced" bson:"is_creator_fees_enforced"`
+}
+
+type User struct {
+	Username string `json:"username" bson:"username"`
+}
+
+type Account struct {
+	User          User    `json:"user" bson:"user"`
+	ProfileImgURL string  `json:"profile_img_url" bson:"profile_img_url"`
+	Address       Address `json:"address" bson:"address"`
+	Config        string  `json:"config" bson:"config"`
+	DiscordID     string  `json:"discord_id" bson:"discord_id"`
+}
+
+type AssetContract struct {
+	Address                     Address     `json:"address" bson:"address"`
+	AssetContractType           string      `json:"asset_contract_type" bson:"asset_contract_type"`
+	CreatedDate                 string      `json:"created_date" bson:"created_date"`
+	Name                        string      `json:"name" bson:"name"`
+	NftVersion                  string      `json:"nft_version" bson:"nft_version"`
+	OpenseaVersion              interface{} `json:"opensea_version" bson:"opensea_version"`
+	Owner                       int64       `json:"owner" bson:"owner"`
+	SchemaName                  string      `json:"schema_name" bson:"schema_name"`
+	Symbol                      string      `json:"symbol" bson:"symbol"`
+	TotalSupply                 interface{} `json:"total_supply" bson:"total_supply"`
+	Description                 string      `json:"description" bson:"description"`
+	ExternalLink                string      `json:"external_link" bson:"external_link"`
+	ImageURL                    string      `json:"image_url" bson:"image_url"`
+	DefaultToFiat               bool        `json:"default_to_fiat" bson:"default_to_fiat"`
+	DevBuyerFeeBasisPoints      int64       `json:"dev_buyer_fee_basis_points" bson:"dev_buyer_fee_basis_points"`
+	DevSellerFeeBasisPoints     int64       `json:"dev_seller_fee_basis_points" bson:"dev_seller_fee_basis_points"`
+	OnlyProxiedTransfers        bool        `json:"only_proxied_transfers" bson:"only_proxied_transfers"`
+	OpenseaBuyerFeeBasisPoints  int64       `json:"opensea_buyer_fee_basis_points" bson:"opensea_buyer_fee_basis_points"`
+	OpenseaSellerFeeBasisPoints int64       `json:"opensea_seller_fee_basis_points" bson:"opensea_seller_fee_basis_points"`
+	BuyerFeeBasisPoints         int64       `json:"buyer_fee_basis_points" bson:"buyer_fee_basis_points"`
+	SellerFeeBasisPoints        int64       `json:"seller_fee_basis_points" bson:"seller_fee_basis_points"`
+	PayoutAddress               Address     `json:"payout_address" bson:"payout_address"`
+}
+
+type Asset struct {
+	// todo: Support commented fields in Asset struct
+	ID                   int64          `json:"id" bson:"id"`
+	TokenID              string         `json:"token_id" bson:"token_id"`
+	NumSales             int64          `json:"num_sales" bson:"num_sales"`
+	BackgroundColor      string         `json:"background_color" bson:"background_color"`
+	ImageURL             string         `json:"image_url" bson:"image_url"`
+	ImagePreviewURL      string         `json:"image_preview_url" bson:"image_preview_url"`
+	ImageThumbnailURL    string         `json:"image_thumbnail_url" bson:"image_thumbnail_url"`
+	ImageOriginalURL     string         `json:"image_original_url" bson:"image_original_url"`
+	AnimationURL         string         `json:"animation_url" bson:"animation_url"`
+	AnimationOriginalURL string         `json:"animation_original_url" bson:"animation_original_url"`
+	Name                 string         `json:"name" bson:"name"`
+	Description          string         `json:"description" bson:"description"`
+	ExternalLink         string         `json:"external_link" bson:"external_link"`
+	AssetContract        *AssetContract `json:"asset_contract" bson:"asset_contract"`
+	Permalink            string         `json:"permalink" bson:"permalink"`
+	Collection           *Collection    `json:"collection" bson:"collection"`
+	Decimals             int64          `json:"decimals" bson:"decimals"`
+	TokenMetadata        string         `json:"token_metadata" bson:"token_metadata"`
+	//IsNSFW               bool           `json:"is_nsfw" bson:"is_nsfw"`
+	Owner *Account `json:"owner" bson:"owner"`
+	//SeaportSellOrders       string         `json:"seaport_sell_orders" bson:"seaport_sell_orders"`
+	//Creator                 *Creator       `json:"creator" bson:"creator"`
+	Traits interface{} `json:"traits" bson:"traits"`
+	//LastSale                string         `json:"last_sale" bson:"last_sale"`
+	//TopBid                  int64          `json:"top_bid" bson:"top_bid"`
+	//ListingDate             string         `json:"listing_date" bson:"listing_date"`
+	//SupportsWyvern          string         `json:"supports_wyvern" bson:"supports_wyvern"`
+	//RarityData              *RarityData    `json:"rarity_data" bson:"rarity_data"`
+	//TransferFee             int64          `json:"transfer_fee" bson:"transfer_fee"`
+	//TransferFeePaymentToken string         `json:"transfer_fee_payment_token" bson:"transfer_fee_payment_token"`
+}
+
+type errorResponse struct {
+	Success bool `json:"success" bson:"success"`
+}
+
+func (e errorResponse) Error() string {
+	return "Not success"
+} 


### PR DESCRIPTION
## Description
- Updated import from `io/ioutil` to `io`
- Replaced deprecated `ioutil.ReadAll()` with `io.ReadAll()` to follow Go 1.16+ recommendations
- Minor formatting improvements to variable declarations

This change maintains the same functionality while using the current recommended API.