### PR TITLE
feat: add Opensea client implementation with mainnet and Rinkeby support

### DIFF
--- a/opensea_client.go
+++ b/opensea_client.go
@@ -1,0 +1,70 @@
+package opensea
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	mainnetAPI  = "https://api.opensea.io"
+	testnetAPI  = "https://testnets-api.opensea.io"
+	rinkebyAPI  = "https://rinkeby-api.opensea.io"
+	basePath    = "/api/v1"
+	contractEP  = basePath + "/asset_contract"
+	assetEP     = basePath + "/asset"
+)
+
+type Opensea struct {
+	API        string
+	APIKey     string
+	httpClient *http.Client
+}
+
+type errorResponse struct {
+	Success bool `json:"success" bson:"success"`
+}
+
+func (e errorResponse) Error() string {
+	return "Operation unsuccessful"
+}
+
+// NewOpensea initializes an Opensea instance for the mainnet.
+func NewOpensea(apiKey string) *Opensea {
+	return &Opensea{
+		API:        mainnetAPI,
+		APIKey:     apiKey,
+		httpClient: newHttpClient(),
+	}
+}
+
+// NewOpenseaRinkeby initializes an Opensea instance for the Rinkeby testnet.
+func NewOpenseaRinkeby(apiKey string) *Opensea {
+	return &Opensea{
+		API:        rinkebyAPI,
+		APIKey:     apiKey,
+		httpClient: newHttpClient(),
+	}
+}
+
+// newHttpClient creates a default HTTP client with a timeout.
+func newHttpClient() *http.Client {
+	return &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   5 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			IdleConnTimeout:       30 * time.Second,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
+


### PR DESCRIPTION
This commit introduces a new Opensea client implementation with the following features:

- Mainnet and Rinkeby Support: Added constructors for initializing Opensea clients specific to the mainnet and Rinkeby testnet.
- Endpoints: Defined constants for commonly used API endpoints such as asset_contract and asset.
- Error Handling: Added a structured errorResponse type to represent API errors with a user-friendly error message.
- HTTP Client: Included a default HTTP client with a configurable timeout and connection settings for efficient network communication.