### PR TITLE
add unit tests for Address parsing and string conversion

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -1,0 +1,37 @@
+package opensea_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"your_project_path/opensea"
+)
+
+func TestParseAddress_Valid(t *testing.T) {
+	input := "0x123456789abcdef"
+	expected := opensea.Address("0x123456789abcdef")
+
+	address, err := opensea.ParseAddress(input)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, address)
+}
+
+func TestParseAddress_EmptyInput(t *testing.T) {
+	input := ""
+
+	address, err := opensea.ParseAddress(input)
+
+	assert.Error(t, err)
+	assert.Equal(t, opensea.NullAddress, address)
+	assert.Equal(t, "empty address", err.Error())
+}
+
+func TestAddressString(t *testing.T) {
+	address := opensea.Address("0x123456789abcdef")
+	expected := "0x123456789abcdef"
+
+	result := address.String()
+
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
- Introduced tests for the `ParseAddress` function to validate correct parsing of valid addresses and error handling for empty inputs.
- Added tests for the `String` method of the `Address` type to ensure accurate string conversion.
- Utilized the `testify` library for concise and expressive assertions.