### PR TITLE
refactor: consolidate API endpoint constants

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,7 +1,12 @@
 package opensea
 
 const (
+	// API endpoints
+	mainnetAPI = "https://api.opensea.io"
 	testnetAPI = "https://testnets-api.opensea.io"
+	rinkebyAPI = "https://rinkeby-api.opensea.io"
+
+	// Resource endpoints
 	contractEP = "/api/v1/asset_contract"
 	assetEP    = "/api/v1/asset"
 	musicEP    = "/api/v1/assets"

--- a/opensea_client.go
+++ b/opensea_client.go
@@ -8,13 +8,6 @@ import (
 	"time"
 )
 
-const (
-	testnetAPI = "https://testnets-api.opensea.io"
-	// rinkebyAPI is already declared
-	contractEP = "/api/v1/asset_contract"
-	assetEP    = "/api/v1/asset"
-)
-
 // Client represents an OpenSea API client
 type Client struct {
 	baseURL    string


### PR DESCRIPTION
- Move API endpoint constants from opensea_client.go to constants.go
- Add mainnetAPI constant for production environment
- Group constants by purpose (API endpoints vs resource endpoints)
- Remove duplicate constant declarations

This change improves code organization by having all API-related constants in a single location, making the codebase more maintainable and reducing duplication.